### PR TITLE
Fixes, Type Safety, and Steam Deck Refresh Rate Override

### DIFF
--- a/src/backend.ts
+++ b/src/backend.ts
@@ -47,3 +47,12 @@ export function setHugePagesState(state: boolean) : ServerResponsePromise<boolea
 export function getHugePagesState(): ServerResponsePromise<boolean> {
     return server!.callPluginMethod("get_huge_pages_state", {});
 }
+
+
+export function setRefreshRateOverride(lower: number, upper: number) : ServerResponsePromise<"" | [number, number]> {
+    return server!.callPluginMethod("set_gamescope_refresh_rate_range", { lower, upper }) as any;
+}
+
+export function getRefreshRateOverride(): ServerResponsePromise<"" | [number, number]> {
+    return server!.callPluginMethod("get_gamescope_refresh_rate_range", {}) as any;
+}

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -1,8 +1,9 @@
-import { ServerAPI } from "decky-frontend-lib"
+import { ServerAPI, ServerResponse } from "decky-frontend-lib"
 
 var server: ServerAPI | undefined = undefined;
+type ServerResponsePromise<T> = Promise<ServerResponse<T>>;
 
-export function resolvePromise(promise: Promise<any>, callback: any) {
+export function resolvePromise<T>(promise: ServerResponsePromise<T>, callback: (value: T) => any) {
     (async function () {
         let data = await promise;
         if (data.success)
@@ -21,28 +22,28 @@ export function setServer(s: ServerAPI) {
 }
 
 
-export function setSSHServerState(state: boolean) : Promise<any> {
+export function setSSHServerState(state: boolean) : ServerResponsePromise<boolean> {
     return server!.callPluginMethod("set_ssh_server_state", { "state": state });
 }
 
-export function getSSHServerState(): Promise<any> {
+export function getSSHServerState(): ServerResponsePromise<boolean> {
     return server!.callPluginMethod("get_ssh_server_state", {});
 }
 
 
-export function setCEFServerState(state: boolean) : Promise<any> {
+export function setCEFServerState(state: boolean) : ServerResponsePromise<boolean> {
     return server!.callPluginMethod("set_cef_debugger_forwarder_state", { "state": state });
 }
 
-export function getCEFServerState(): Promise<any> {
+export function getCEFServerState(): ServerResponsePromise<boolean> {
     return server!.callPluginMethod("get_cef_debugger_forwarder_state", {});
 }
 
 
-export function setHugePagesState(state: boolean) : Promise<any> {
+export function setHugePagesState(state: boolean) : ServerResponsePromise<boolean> {
     return server!.callPluginMethod("set_huge_pages_state", { "state": state });
 }
 
-export function getHugePagesState(): Promise<any> {
+export function getHugePagesState(): ServerResponsePromise<boolean> {
     return server!.callPluginMethod("get_huge_pages_state", {});
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,18 +10,52 @@ import { VFC, useState, useEffect } from "react";
 import { FaToolbox } from "react-icons/fa";
 
 import * as backend from "./backend"
- 
+
+function RefreshRateOverrideDescription({querying, supported}: {querying: boolean, supported: boolean}) {
+    return (
+        <div>
+            <span>
+                Extends the ranges of supported refresh rates.{" "}
+            </span>
+            {(!querying && !supported) && <span style={{color: "red"}}>
+                This is not supported on your OS.
+            </span>}
+            {(!querying && supported) && <span>
+                Requires restart to take effect.
+            </span>}
+        </div>
+    )
+}
+
 const Content: VFC<{ server: ServerAPI }> = ({server}) => {
     backend.setServer(server);
 
     const [sshServerToggleValue, setSshServerToggleState]   = useState<boolean>(false);
     const [cefServerToggleValue, setCefServerToggleState]   = useState<boolean>(false);
     const [largePagesToggleValue, setLargePagesToggleState] = useState<boolean>(false);
+    const [refreshRateQuerying, setRefreshRateQuerying]     = useState<boolean>(true);
+    const [refreshRateSupported, setRefreshRateSupported]   = useState<boolean>(true);
+    const [refreshRateRange, setRefreshRateRange]           = useState<[number,number]|null>(null);
+
+    const refreshRateRangeIsStock = refreshRateRange != null
+        && refreshRateRange[0] === 40 && refreshRateRange[1] === 60;
+
+    const handleRefreshRateOverrideResponse = (range: string|[number, number]) => {
+        setRefreshRateQuerying(false);
+        if (range instanceof Array) {
+            setRefreshRateSupported(true);
+            setRefreshRateRange(range);
+        } else {
+            setRefreshRateSupported(false);
+        }
+
+    }
 
     useEffect(() => {
         backend.resolvePromise(backend.getSSHServerState(), setSshServerToggleState);
         backend.resolvePromise(backend.getCEFServerState(), setCefServerToggleState);
         backend.resolvePromise(backend.getHugePagesState(), setLargePagesToggleState);
+        backend.resolvePromise(backend.getRefreshRateOverride(), handleRefreshRateOverrideResponse);
     }, []);
 
     return (
@@ -60,6 +94,28 @@ const Content: VFC<{ server: ServerAPI }> = ({server}) => {
                         onChange={(value: boolean) => {
                             backend.setHugePagesState(value);
                             setLargePagesToggleState(value);
+                        }}
+                    />
+                </PanelSectionRow>
+
+                <PanelSectionRow>
+                    <ToggleField
+                        label="Steam Deck Refresh Rate Override"
+                        description={<RefreshRateOverrideDescription querying={refreshRateQuerying} supported={refreshRateSupported}/>}
+                        disabled={!refreshRateSupported || refreshRateQuerying}
+                        checked={!refreshRateRangeIsStock}
+                        onChange={(value: boolean) => {
+                            const valueRange: [number, number] = value ? [30,70] : [40,60];
+
+                            // Pretend we toggled it while we wait for a response.
+                            setRefreshRateRange(valueRange);
+                            setRefreshRateQuerying(true);
+
+                            // Tell the Python script to update the gamemode-session script.
+                            // After that returns, refresh the toggle field.
+                            backend.setRefreshRateOverride(...valueRange).then(() => {
+                                backend.resolvePromise(backend.getRefreshRateOverride(), handleRefreshRateOverrideResponse);
+                            });
                         }}
                     />
                 </PanelSectionRow>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,7 @@ import {
     staticClasses,
     ToggleField,
 } from "decky-frontend-lib";
-import { VFC, useState } from "react";
+import { VFC, useState, useEffect } from "react";
 import { FaToolbox } from "react-icons/fa";
 
 import * as backend from "./backend"
@@ -18,9 +18,11 @@ const Content: VFC<{ server: ServerAPI }> = ({server}) => {
     const [cefServerToggleValue, setCefServerToggleState]   = useState<boolean>(false);
     const [largePagesToggleValue, setLargePagesToggleState] = useState<boolean>(false);
 
-    backend.resolvePromise(backend.getSSHServerState(), setSshServerToggleState);
-    backend.resolvePromise(backend.getCEFServerState(), setCefServerToggleState);
-    backend.resolvePromise(backend.getHugePagesState(), setLargePagesToggleState);
+    useEffect(() => {
+        backend.resolvePromise(backend.getSSHServerState(), setSshServerToggleState);
+        backend.resolvePromise(backend.getCEFServerState(), setCefServerToggleState);
+        backend.resolvePromise(backend.getHugePagesState(), setLargePagesToggleState);
+    }, []);
 
     return (
         <PanelSection>


### PR DESCRIPTION
Hi there! I have a couple contributions to make, if you would be willing to look over them and merge them. This pull request contains a series of commits that improve various aspects of the System Toolbox Decky plugin.

## Commits

Third first commit fixes a longstanding issue that causes the plugin to behave unresponsively when toggling settings.

The second commit adds some type safety to the backend.ts functions that handles RPC between the front-end UI and the backend Python script.

The final commit adds a new option to override the refresh rate limits under `gamescope-session`, increasing the available range from Valve's limits of `40-60` to the community's tested limits of `30-70`. It also adds a fancy Python context that will temporarily change the root filesystem from read-only to writable, which allows for a lot more potential to modify system behaviour.
