### PR TITLE
Add Toggle for Avahi Daemon / mDNS

### DIFF
--- a/main.py
+++ b/main.py
@@ -24,6 +24,14 @@ class Plugin:
     async def set_ssh_server_state(self, state):
         return self._set_service_state(self, "sshd", state)
 
+    ### Avahi Server
+
+    async def get_avahi_server_state(self):
+        return self._get_service_state(self, "avahi-daemon")
+
+    async def set_avahi_server_state(self, state):
+        return self._set_service_state(self, "avahi-daemon", state)
+
 
     ### CEF Debugging Forwarding
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -29,6 +29,14 @@ export function getSSHServerState(): Promise<any> {
     return server!.callPluginMethod("get_ssh_server_state", {});
 }
 
+export function setAvahiServerState(state: boolean) : Promise<any> {
+    return server!.callPluginMethod("set_avahi_server_state", { "state": state });
+}
+
+export function getAvahiServerState(): Promise<any> {
+    return server!.callPluginMethod("get_avahi_server_state", {});
+}
+
 
 export function setCEFServerState(state: boolean) : Promise<any> {
     return server!.callPluginMethod("set_cef_debugger_forwarder_state", { "state": state });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -42,7 +42,7 @@ const Content: VFC<{ server: ServerAPI }> = ({server}) => {
                 <PanelSectionRow>
                     <ToggleField
                         label="Remote Terminal Access"
-                        description="Gives access to the Deck over SSH"
+                        description="Enable Avahi daemon for MDNS"
                         checked={avahiServerToggleValue}
                         onChange={(value: boolean) => {
                             backend.setAvahiServerState(value);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -41,7 +41,7 @@ const Content: VFC<{ server: ServerAPI }> = ({server}) => {
 
                 <PanelSectionRow>
                     <ToggleField
-                        label="Remote Terminal Access"
+                        label="Avahi Daemon / MDNS"
                         description="Enable Avahi daemon for MDNS"
                         checked={avahiServerToggleValue}
                         onChange={(value: boolean) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -15,10 +15,12 @@ const Content: VFC<{ server: ServerAPI }> = ({server}) => {
     backend.setServer(server);
 
     const [sshServerToggleValue, setSshServerToggleState]   = useState<boolean>(false);
+    const [avahiServerToggleValue, setAvahiServerToggleState]   = useState<boolean>(false);
     const [cefServerToggleValue, setCefServerToggleState]   = useState<boolean>(false);
     const [largePagesToggleValue, setLargePagesToggleState] = useState<boolean>(false);
 
     backend.resolvePromise(backend.getSSHServerState(), setSshServerToggleState);
+    backend.resolvePromise(backend.getAvahiServerState(), setAvahiServerToggleState);
     backend.resolvePromise(backend.getCEFServerState(), setCefServerToggleState);
     backend.resolvePromise(backend.getHugePagesState(), setLargePagesToggleState);
 
@@ -33,6 +35,18 @@ const Content: VFC<{ server: ServerAPI }> = ({server}) => {
                         onChange={(value: boolean) => {
                             backend.setSSHServerState(value);
                             setSshServerToggleState(value);
+                        }}
+                    />
+                </PanelSectionRow>
+
+                <PanelSectionRow>
+                    <ToggleField
+                        label="Remote Terminal Access"
+                        description="Gives access to the Deck over SSH"
+                        checked={avahiServerToggleValue}
+                        onChange={(value: boolean) => {
+                            backend.setAvahiServerState(value);
+                            setAvahiServerToggleState(value);
                         }}
                     />
                 </PanelSectionRow>


### PR DESCRIPTION
Literally just a copy / paste of the SSH toggle, with the systemd service switched to `avahi-daemon`. Avahi is preinstalled, just not enabled.